### PR TITLE
Update README.md to remove ‘easy’

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For real usage examples, you can check the collections section on my personal **
 
 # Installation
 
-Installing `diego` is easy. You can either compile it from source or download the official binaries from the [releases](https://github.com/ttybitnik/diego/releases).
+You can either compile `diego` from source or download the official binaries from the [releases](https://github.com/ttybitnik/diego/releases).
 
 > [!TIP]
 > After following the instructions for your preferred installation method, run `diego -v` to test the installed version.


### PR DESCRIPTION
Hi @ttybitnik! This looks like an interesting project. Just spotted a slight issue in the README, which describes installation as being ‘easy’ (prior to mention of ‘compiling’ and ‘binaries’). [Here’s a blog post](https://boshdirect.com/joshlyon/hidden-power-of-just-easy-simply-and-linguistic-minimization/) that outlines why this language should be avoided in technical documentation.